### PR TITLE
Uppdatering av SM-protokollmallen (2013)

### DIFF
--- a/sekreterare/protokoll/prot_sm-YYYY-MM-DD.tex
+++ b/sekreterare/protokoll/prot_sm-YYYY-MM-DD.tex
@@ -87,11 +87,12 @@ Se bilaga för mer information.
       \end{enumerate}
     \item \textbf{Övriga funktionärer}
       \begin{enumerate}
-        \item \textbf{D.E.M.O.N}
+      	\item \textbf{DAD}
+        \item \textbf{DEMON}
+        \item \textbf{DESCtop}
         \item \textbf{DIU}
         \item \textbf{DKM}
         \item \textbf{Fanbärare}
-        \item \textbf{Fenixorden}
         \item \textbf{Ior}
         \item \textbf{Jämlikhetsnämnden}
         \item \textbf{KF-ledamöter}
@@ -100,7 +101,6 @@ Se bilaga för mer information.
         \item \textbf{METAdorerna}
         \item \textbf{Mottagningen}
   			\item \textbf{Mulle/Mullerina}
-        \item \textbf{NULL}
         \item \textbf{Näringslivsgruppen}
         \item \textbf{Programansvarig student}
         \item \textbf{Prylmånglaren}
@@ -109,29 +109,28 @@ Se bilaga för mer information.
         \item \textbf{Revisorer}
         \item \textbf{Sektionshistoriker}
         \item \textbf{Sektionsidrottsnämnden}
-        \item \textbf{Spexmästeriet}
         \item \textbf{Studienämnden}
+        \item \textbf{Styvfar}
         \item \textbf{Valberedningens ordförande} 
       \end{enumerate}
     \item \textbf{Kåren}
     \item \textbf{Projekt}
       \begin{enumerate}
-        \item \textbf{dÅre2013}
-        \item \textbf{Jubileumsprojektet}
+        \item \textbf{dÅre2014}
         \item \textbf{METAspexet}
-        \item \textbf{studs2013}
+        \item \textbf{studs2014}
       \end{enumerate}
     \item \textbf{Sektionen för Medieteknik}
   \end{enumerate}
 
 
 %\punkt{Bordlagda ärenden}
-% UPPDATERAD 2013-01-30
+% UPPDATERAD 2013-11-26
 %  \begin{enumerate}
 %    \item \textbf{Val av kassör}
-%    \item \textbf{Verksamhetsberättelse för 2011}
-%    \item \textbf{Resultatrapport för 2011}
-%    \item \textbf{Ansvarsfrihet för verksamhetsåret 2011}
+%    \item \textbf{Verksamhetsberättelse för 2012}
+%    \item \textbf{Resultatrapport för 2012}
+%    \item \textbf{Ansvarsfrihet för verksamhetsåret 2012}
 %  \end{enumerate}
 
 


### PR DESCRIPTION
Uppdaterade funktionärslistan under "Rapporter", tog bort Fenixorden och
Spexmästeriet och la till DAD, Styvfar och DESCtop. Ändrade studs och
dåre till 2014.
