### PR TITLE
Uppdatering av SMdagordningsmall (2013)

### DIFF
--- a/sekreterare/dagordning/dagordning_sm-YYYY-MM-DD.tex
+++ b/sekreterare/dagordning/dagordning_sm-YYYY-MM-DD.tex
@@ -52,12 +52,14 @@
       \end{enumerate}
     \item \textbf{Övriga funktionärer}
     % Uppdatera när nya nämnder skapas/tas bort.
+    % Senast uppdaterad: 2013-11-26
       \begin{enumerate}
-        \item \textbf{D.E.M.O.N}
+      	\item \textbf{DAD}
+        \item \textbf{DEMON}
+        \item \textbf{DESCtop}
         \item \textbf{DIU}
         \item \textbf{DKM}
         \item \textbf{Fanbärare}
-        \item \textbf{Fenixorden}
         \item \textbf{Ior}
         \item \textbf{Jämlikhetsnämnden}
         \item \textbf{KF-ledamöter}
@@ -74,7 +76,6 @@
         \item \textbf{Revisorer}
         \item \textbf{Sektionshistoriker}
         \item \textbf{Sektionsidrottsnämnden}
-        \item \textbf{Spexmästeriet}
         \item \textbf{Studienämnden}
         \item \textbf{STYFV}
         \item \textbf{Valberedningen} 
@@ -82,11 +83,11 @@
     \item \textbf{Kåren}
     \item \textbf{Projekt}
     % Uppdatera när projekt skapas/avslutas, missa ej årtalen.
+    % Senast uppdaterad: 2013-11-26
       \begin{enumerate}
-        \item \textbf{dÅre2013}
-        \item \textbf{Jubileumsprojektet}
+        \item \textbf{dÅre2014}
         \item \textbf{METAspexet}
-        \item \textbf{studs2013}
+        \item \textbf{studs2014}
       \end{enumerate}
     \item \textbf{Sektionen för Medieteknik}
   \end{enumerate}
@@ -99,9 +100,6 @@
 % Uppdatera genom att gå igenom senaste SM-protokollet.
 % UPPDATERAD 2013-02-13
 %  \begin{enumerate}
-%    \item \textbf{Verksamhetsberättelse för 2011}
-%    \item \textbf{Resultatrapport för 2011}
-%    \item \textbf{Ansvarsfrihet för verksamhetsåret 2011}
 %    \item \textbf{Verksamhetsberättelse för 2012}
 %    \item \textbf{Resultatrapport för 2012}
 %    \item \textbf{Ansvarsfrihet för verksamhetsåret 2012}


### PR DESCRIPTION
Uppdaterade funktionärslistan: Tog bort Fenixorden och Spexmästeriet och
la till DAD och Desctop, samt tog bort punkterna i DEMON.
