### PR TITLE
Ändring: Redaqtionen utbytt mot Chefredaqteur

### DIFF
--- a/sekreterare/dagordning/dagordning_sm-YYYY-MM-DD.tex
+++ b/sekreterare/dagordning/dagordning_sm-YYYY-MM-DD.tex
@@ -54,6 +54,7 @@
     % Uppdatera när nya nämnder skapas/tas bort.
     % Senast uppdaterad: 2013-11-26
       \begin{enumerate}
+      	\item \textbf{Chefredaqteur}
       	\item \textbf{DAD}
         \item \textbf{DEMON}
         \item \textbf{DESCtop}
@@ -72,7 +73,6 @@
         \item \textbf{Programansvarig student}
         \item \textbf{Prylmånglaren}
         \item \textbf{QN}
-        \item \textbf{Redaqtionen} 
         \item \textbf{Revisorer}
         \item \textbf{Sektionshistoriker}
         \item \textbf{Sektionsidrottsnämnden}

--- a/sekreterare/protokoll/prot_sm-YYYY-MM-DD.tex
+++ b/sekreterare/protokoll/prot_sm-YYYY-MM-DD.tex
@@ -87,6 +87,7 @@ Se bilaga för mer information.
       \end{enumerate}
     \item \textbf{Övriga funktionärer}
       \begin{enumerate}
+      	\item \textbf{Chefredaqteur}
       	\item \textbf{DAD}
         \item \textbf{DEMON}
         \item \textbf{DESCtop}
@@ -97,15 +98,14 @@ Se bilaga för mer information.
         \item \textbf{Jämlikhetsnämnden}
         \item \textbf{KF-ledamöter}
         \item \textbf{KÖN}
-  			\item \textbf{Ljud- och ljusansvarig}
+  		\item \textbf{Ljud- och ljusansvarig}
         \item \textbf{METAdorerna}
         \item \textbf{Mottagningen}
-  			\item \textbf{Mulle/Mullerina}
+  		\item \textbf{Mulle/Mullerina}
         \item \textbf{Näringslivsgruppen}
         \item \textbf{Programansvarig student}
         \item \textbf{Prylmånglaren}
         \item \textbf{QN}
-        \item \textbf{Redaqtionen} 
         \item \textbf{Revisorer}
         \item \textbf{Sektionshistoriker}
         \item \textbf{Sektionsidrottsnämnden}


### PR DESCRIPTION
Eftersom Redaqtionen inte längre finns som sådan tog jag bort
Redaqtionen från funktionärslistan och ersatte det med Chefredaqteur
eftersom funkisposten fortfarande finns kvar.
